### PR TITLE
Simplify intersperseWith

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,7 @@ var result = segregateBy(condition, items);
 ```
 
 ##### intersperseWith(function, itemArray)
-Inserts the return value of a function into an array, by alternatively calling it with the array element and a function that you can use to return the separator.
-This is useful if your array is not a primitive, e.g. if you have an array of dom nodes, or react elements and want to insert some other dom nodes, like dom separators, this function lets you easily achieve that.
+Inserts the return value of a function into an array. This is very similar to Ramda's intersperse with the only difference being that it invokes a function for every index at which the separator will be insered e.g. This is especially handy if you have an array of dom nodes or react elements and want to insert some other dom nodes, like dom separators
 
 ```js
 var items = [
@@ -248,7 +247,7 @@ var items = [
   "<span>BAZ</span>",
 ];
 
-function getElement(value, idx) { return value !== undefined ? value : `<span key="separator-${idx}">--</span>` };
+function getElement(value, idx) { return `<span key="separator-${idx}">--</span>` };
 
 var result = getElement(getSeparator, items)
 

--- a/intersperseWith.js
+++ b/intersperseWith.js
@@ -1,14 +1,13 @@
 /**
  * Inserts the return value of a function into an array. This is very similar to Ramda's intersperse
- * with the only difference being that this function also accepts a function as an argument
- * that is invoked alternatively with the array element and once with nothing so you can return a custom separator
- * This is useful if your array is not a primitive, e.g. if you have an array of dom nodes, or react elements
- * and want to insert some other dom nodes, like dom separators, this function lets you easily achieve that.
+ * with the only difference being that it invokes a function for every index at which the separator will be insered
+ * e.g. This is especially handy if you have an array of dom nodes or react elements
+ * and want to insert some other dom nodes, like dom separators
  * @param {Function} getSeparator A function that returns the separator to be inserted
  * @param {Array} arr An array of arbitrary data
  * @returns
  */
-function intersperseWith(fn, arr) {
+function intersperseWith(getSeparator, arr) {
   var len = arr.length;
   if (len === 0) return [];
   var result = [],
@@ -19,9 +18,9 @@ function intersperseWith(fn, arr) {
 
   while (index < totalElements) {
     if (index % 2 === 0) {
-      result.push(fn(arr[index - numberOfSeparators], index));
+      result.push(arr[index - numberOfSeparators]);
     } else {
-      result.push(fn(undefined, index));
+      result.push(getSeparator(index));
       numberOfSeparators++;
     }
     index++;

--- a/tests/intersperseWith.test.js
+++ b/tests/intersperseWith.test.js
@@ -6,24 +6,23 @@ var intersperseWith = require(ROOT + "/intersperseWith");
 
 describe("intersperseWith", () => {
   it("returns an array with the separator interspersed between array elements", () => {
-    const getElement = (value, idx) =>
-      value !== undefined ? value : `<span key="${idx}">--</span>`;
+    const getSeparator = (idx) => `<span key="${idx}">--</span>`;
 
     const foo = "<span>FOO</span>";
     const bar = "<span>BAR</span>";
     const baz = "<span>BAZ</span>";
 
-    expect(intersperseWith(getElement, [])).to.deep.equal([]);
+    expect(intersperseWith(getSeparator, [])).to.deep.equal([]);
 
-    expect(intersperseWith(getElement, [0])).to.deep.equal([0]);
+    expect(intersperseWith(getSeparator, [0])).to.deep.equal([0]);
 
-    expect(intersperseWith(getElement, [0, 2])).to.deep.equal([
+    expect(intersperseWith(getSeparator, [0, 2])).to.deep.equal([
       0,
       `<span key="1">--</span>`,
       2,
     ]);
 
-    expect(intersperseWith(getElement, [foo, bar, baz])).to.deep.equal([
+    expect(intersperseWith(getSeparator, [foo, bar, baz])).to.deep.equal([
       foo,
       '<span key="1">--</span>',
       bar,


### PR DESCRIPTION
Invoke the getSeparator function only when inserting the separator.